### PR TITLE
search_project_path related fixes for linux, osx, wsl

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -186,9 +186,10 @@ class Verilator(Linter):
                     for path in prjsrc:
                         if sublime.platform() == 'windows':
                             if wslopt:
-                                path = '/mnt/' + re.sub(':', '', path)
-                            path = '-I' + re.sub(re.compile(r'\\'), '/', path)
-                            cmd.append(path)
+                                path = re.sub(r'(^[a-zA-Z])(:)(.*$)',lambda m : ''.join(['/mnt/',m.group(1).lower(),m.group(3)]),path)
+                            path = re.sub(re.compile(r'\\'), '/', path)
+                        path = '-I' + path
+                        cmd.append(path)
 
             with make_temp_file(suffix, code) as file:
                 ctx = get_view_context(self.view)
@@ -196,7 +197,7 @@ class Verilator(Linter):
                 if sublime.platform() == 'windows':
                     if wslopt:
                         orig_file = file.name
-                        file.name = '/mnt/' + re.sub(':', '', file.name)
+                        file.name = re.sub(r'(^[a-zA-Z])(:)(.*$)',lambda m : ''.join(['/mnt/',m.group(1).lower(),m.group(3)]),file.name)
                     file.name = re.sub(re.compile(r'\\'), '/', file.name)
                 ctx['temp_file'] = file.name
                 cmd.append(file.name)
@@ -219,8 +220,8 @@ class Verilator(Linter):
                         if wslopt:
                             orig_file = file.name
                             orig_wrap = wrap.name
-                            file.name = '/mnt/' + re.sub(':', '', file.name)
-                            wrap.name = '/mnt/' + re.sub(':', '', wrap.name)
+                            file.name = re.sub(r'(^[a-zA-Z])(:)(.*$)',lambda m : ''.join(['/mnt/',m.group(1).lower(),m.group(3)]),file.name)
+                            wrap.name = re.sub(r'(^[a-zA-Z])(:)(.*$)',lambda m : ''.join(['/mnt/',m.group(1).lower(),m.group(3)]),wrap.name)
                         file.name = re.sub(re.compile(r'\\'), '/', file.name)
                         wrap.name = re.sub(re.compile(r'\\'), '/', wrap.name)
                     ctx['temp_file'] = file.name


### PR DESCRIPTION
Redoing this pull request so it isn't tracking all the changes in my fork -

This PR should fix:
- Relative project paths in WSL not working (`/mnt/` was being added to rel. paths)
- Capital drive letters not being converted to lowercase for WSL ( `C:` needs to be changed to `/mnt/c` not `/mnt/C` etc.)
- search_project_path being ignored for non-windows platforms ( #8 )

I believe the project also needs to be updated to use python 3.8 to work with the latest SublimeLinter version, but I haven't included those changes here as it may break someone's setup.